### PR TITLE
Changed the title for project name and prefix

### DIFF
--- a/modules/ROOT/pages/project-name-and-prefix.adoc
+++ b/modules/ROOT/pages/project-name-and-prefix.adoc
@@ -1,5 +1,5 @@
 // section_id_prefix: pnpp_
-= Project Name and the Project Prefix
+= Choose a Project Name and a Project Prefix
 
 "There are only two hard things in Computer Science: cache invalidation and naming things."
 -- Phil Karlton, https://www.karlton.org/2017/12/naming-things-hard/[^]


### PR DESCRIPTION
Changed the title of the best practice to choose
always a project name and prefix. Using a verb
at the beginning of a title sounds better.