### PR TITLE
Antora Collector now scans log files recursively

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -24,5 +24,5 @@ ext:
         dir: modules/ROOT/examples/dependencies-update-1
     scan:
       dir: modules/ROOT/examples/dependencies-update-1
-      files: '*.log'
+      files: '**/*.log'
       into: modules/ROOT/examples


### PR DESCRIPTION
Antora Collector scans now via `**/*.log` for logfiles below `modules/ROOT/examples`.