### PR TITLE
Fixed failing includes in some articles

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -23,6 +23,10 @@ ext:
       - command: cp pom.xml.original pom.xml
         dir: modules/ROOT/examples/dependencies-update-1
     scan:
-      dir: modules/ROOT/examples/dependencies-update-1
-      files: '**/*.log'
+      dir:
+        - modules/ROOT/examples/dependencies-update-1
+      files:
+        - '**/*.log'
+        - '**/*.xml'
+        - '**/*.xml.updated'
       into: modules/ROOT/examples


### PR DESCRIPTION
Enhanced the scanning action. Until now it does not include all required files. Now, all the necessary files will be imported and all includes can now be resolved.