### PR TITLE
Specify and enforce Maven version to be used

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,6 +22,8 @@ ext:
         dir: modules/ROOT/examples/dependencies-update-1
       - command: mvn --log-file ../../generated/dependencies-update-2.log --no-transfer-progress versions:update-properties
         dir: modules/ROOT/examples/dependencies-update-1
+      - command: mvn --fail-never --log-file ../../generated/require-maven-version.log --no-transfer-progress verify
+        dir: modules/ROOT/examples/specify-maven-version
       - command: cp pom.xml ../../generated/pom.xml.updated
         dir: modules/ROOT/examples/dependencies-update-1
       - command: cp pom.xml.original pom.xml

--- a/modules/ROOT/examples/specify-maven-version/pom.xml
+++ b/modules/ROOT/examples/specify-maven-version/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.amce.systems.specify.maven.version</groupId> <!--2-->
+    <artifactId>specify-maven-version-parent</artifactId>
+    <version>0.1.0</version>
+
+    <!-- tag::enforcer[] -->
+    <properties>
+        <!-- Property used by the Maven Wrapper plugin and the
+             Maven Enforcer Plugin so that both can refer to the
+             same Maven version. -->
+        <mavenVersion>3.9.10</mavenVersion> <!--1-->
+        <spm.enforcer-plugin.version>3.6.2</spm.enforcer-plugin.version>
+        <spm.maven-wrapper-plugin.version>3.3.4</spm.maven-wrapper-plugin.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${spm.enforcer-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[${mavenVersion}]</version> <!--2-->
+                                    <message>
+        This project requires Maven ${mavenVersion}. You are using Maven
+        ${maven.version}. Please ensure you are using the correct Maven
+        version via the Maven wrapper. Run mvn wrapper:wrapper to ensure
+        that the configuration of the Enforcer plugin and the Maven Wrapper
+        plugin are in sync. <!--3-->
+                                    </message>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-wrapper-plugin</artifactId>
+                <version>${spm.maven-wrapper-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+    <!-- end::enforcer[] -->
+</project>

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -7,3 +7,4 @@
 ** xref:dont-abuse-maven.adoc[]
 ** xref:keep-your-dependecies-up-to-date.adoc[]
 ** xref:project-name-and-prefix.adoc[]
+** xref:specify-always-maven-version.adoc[]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -18,3 +18,4 @@ As soon as I have gathered enough knowledge about Maven 4, I will update and ext
 . xref:dont-abuse-maven.adoc[]
 . xref:keep-your-dependecies-up-to-date.adoc[]
 . xref:project-name-and-prefix.adoc[]
+. xref:specify-always-maven-version.adoc[]

--- a/modules/ROOT/pages/project-name-and-prefix.adoc
+++ b/modules/ROOT/pages/project-name-and-prefix.adoc
@@ -22,6 +22,14 @@ So, let's get started.
 [#pnpp_rationale]
 == Rationale
 
+Notizen, zum übersetzen
+
+1. Manche Maven-Versionen erfordern eine bestimmte Maven-Version
+2. Es drückt klar die Mindestanforderung aus (CGM: Installer funktionierte mit neueren Maven-Versionen nicht - stimmt das? Verhalten kann sich ändern in Zusammenspiel von Versionen von Maven und Plugins)
+3. Vermeiden, dass unterschiedliche Maven-Versionen eingesetzt werden. Bei der CGM habe ich 2025 noch 3.0.5 benötigt
+4. Einhaltung wird durch das projekt selber sichergestellt
+
+
 "If you think your project deserves a dedicated Maven project, then it also deserves its own name and namespace."
 -- Oliver B. Fischer
 
@@ -55,7 +63,9 @@ include::example$common-billing-system/pom.xml[]
 <3> `cbs` will be also used as a common prefix for all project specific Maven properties, to differentiate them from properties used by plugins for Maven and Maven itself
 <4> Also, each Maven module will use the same prefix to ensure that it has a unique name for the module
 
+
 [#pnpp_seealso]
 == See also
 
 * xref:always-prefix-custom-maven-properties.adoc[]
+

--- a/modules/ROOT/pages/specify-always-maven-version.adoc
+++ b/modules/ROOT/pages/specify-always-maven-version.adoc
@@ -1,0 +1,71 @@
+// section_id_prefix: asmv_
+= Always specify the Maven version to be used
+:url-maven-wrapper: https://maven.apache.org/tools/wrapper/
+:url-maven-enforder-plugin: https://maven.apache.org/enforcer/maven-enforcer-plugin/
+:url-maven-version-plugin: https://www.mojohaus.org/versions/versions-maven-plugin/
+:url-maven-version-ranges: https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
+
+[#asmv_recommendation]
+== Recommendation
+
+1. Specify the Maven version required for the Maven project.
+
+[#asmv_rationale]
+== Rationale
+
+
+Apache Maven is constantly being developed. Although there are no obvious major differences between versions, there are still relevant variations between them.
+
+There are fifteen years between versions 3.0 and 3.9.12.
+Maven 3.8 required Java 7 at least, whereas from version 3.9 onwards, Java 8 was required.
+
+Some projects can be built with either Maven 3.3 or Maven 3.9.12 without any issues. However, some projects behave differently depending on the Maven version used.
+This is because the individual Maven versions use different default plugin versions.
+
+These differences can easily be traced in the documentation for the plugin versions at https://maven.apache.org/ref/3.9.12/maven-core/default-bindings.html[version 3.9.1] and https://maven.apache.org/ref/3.8.5/maven-core/default-bindings.html[version 3.8.5^].
+For example, Version 3.9.12 uses Maven Compiler Plugin 3.13.0, whereas Version 3.8.5 uses Maven Compiler Plugin 3.1.
+
+Especially in projects with multiple developers or different Maven versions in development and in the CI pipeline, errors can occur that are difficult to trace.
+
+By using the Maven Enforcer plugin to enforce the desired Maven version, you can ensure that the correct Maven version is used and that the build is stable and traceable.
+
+[#asmv__example]
+== Example
+
+This example demonstrates how to enforce a specific Maven version using the Maven Enforcer plugin.
+By specifying a custom error message, the Maven property `maven.version`, which contains the version of Maven used to execute the build, can also be included in the error message.
+Having both the required and effective Maven versions in the error message makes the problem much easier to understand and solve.
+
+Please note that the required Maven version is specified using the Maven property mavenVersion in the configuration shown.
+This property is also used by the {url-maven-wrapper}[Maven Wrapper^] to specify the Maven version to be wrapped.
+If `mavenVersion` is used to configure both the Maven Enforcer plugin and the Maven Wrapper, the two plugins are synchronised.
+
+
+.Use the Maven Enforcer plugin to enforce a specific Maven version.
+[source,xml,indent=0]
+----
+include::example$specify-maven-version/pom.xml[tags=enforcer]
+----
+
+<1> Specifying the required Maven version:
+<2> Specifying the Maven version to be enforced by the Maven Enforcer plugin:
+It is important to use `[...]` to enforce this exact version.
+If the required version were specified as `<version>++${mavenVersion}++</version>`, any Maven version from the specified version onwards (`>=`) would be accepted.
+Using `<version>[+++${mavenVersion}+++]</version>` restricts the version to the exact specified Maven version (`=`).
+Details on specifying versions can be found on the Enforcer Version Range Specification page.
+<3> The formatting of the `message` element has been adjusted for this example to make the listing easier to read.
+
+
+.Effective error message from the Maven Enforcer plugin
+[source,xml]
+----
+include::example$require-maven-version.log[]
+----
+
+[#asmv_references]
+== References
+
+. {url-maven-enforder-plugin}[Maven Enforcer Plugin^]
+. {url-maven-version-ranges}[Enforcer Version Range Specification^]
+. {url-maven-wrapper}[Maven Wrapper^]
+. {url-maven-version-plugin}[Maven Version Plugin^]


### PR DESCRIPTION
Added best practice for Maven, recommending
to enforce the Maven version to be used
via the Maven Enforcer Plugin