### PR TITLE
Run antora with option --stacktrace in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: Install Antora
         run: npm clean-install
       - name: Generate Site
-        run: npx antora antora-playbook.yml
+        run: npx --stacktrace antora antora-playbook.yml


### PR DESCRIPTION
Antora is now always executed with the
--stacktrace option in the CI pipeline
to make it easier to trace errors.